### PR TITLE
minor updates to documents

### DIFF
--- a/GetStarted.md
+++ b/GetStarted.md
@@ -175,7 +175,7 @@ That ends this Get Started CLI example. As a next step, you can also follow the
 [Beyond Get Started CLI Example](examples/cli/README.md) for a complete example
 that includes evaluation, benchmarking, and quantization in the datasets.
 
-Read about all the CLI commands in the [CLI reference](/cli.md).
+Read about all the CLI commands in the [CLI reference](https://intelai.github.io/transfer-learning/main/cli.html).
 Find more examples in our list of [Examples](examples/README.md).
 
 ### Run Using the Low-Code API
@@ -244,7 +244,7 @@ optimization_output = os.path.join(output_dir, "optimized_model")
 model.optimize_graph(optimization_output, overwrite_model=True)
 ```
 
-For more information on the API, see the [API Documentation](/api.md).
+For more information on the API, see the [API Documentation](https://intelai.github.io/transfer-learning/main/api.html).
 
 ## Summary and Next Steps
 
@@ -256,8 +256,8 @@ For the no-code CLI, you can follow a
 complete example that includes trainng, evaluation, benchmarking, and quantization
 in the datasets, as well as some additional models in the [Beyond Get Started
 CLI example](examples/cli/README.md) documentation. You can also read about all the
-CLI commands in the [CLI reference](/cli.md).
+CLI commands in the [CLI reference](https://intelai.github.io/transfer-learning/main/cli.html).
 
-For the low-code API, read about the API in the [API Documentation](/api.md).
+For the low-code API, read about the API in the [API Documentation](https://intelai.github.io/transfer-learning/main/api.html).
 
 Find more CLI and API examples in our list of [Examples](examples/README.md).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ demonstrate its usage.
 * Supports PyTorch\* and TensorFlow\*
 * Select from over [100 image classification and text classification models](Models.md) from
   Torchvision, PyTorch Hub, TensorFlow Hub, Keras, and Hugging Face
-* Use your own custom dataset or get started quickly with [built-in datasets](DATASETS.md)
+* Use your own custom dataset or get started quickly with built-in datasets
 * Automatically create a trainable classification layer customized for your dataset
 * Pre-process your dataset using scaling, cropping, batching, and splitting
 * Use APIs for prediction, evaluation, and benchmarking

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ demonstrate its usage.
 * Supports PyTorch\* and TensorFlow\*
 * Select from over [100 image classification and text classification models](Models.md) from
   Torchvision, PyTorch Hub, TensorFlow Hub, Keras, and Hugging Face
-* Use your own custom dataset or get started quickly with built-in datasets
+* Use your own custom dataset or get started quickly with [built-in datasets](DATASETS.md)
 * Automatically create a trainable classification layer customized for your dataset
 * Pre-process your dataset using scaling, cropping, batching, and splitting
 * Use APIs for prediction, evaluation, and benchmarking

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,9 +24,6 @@ docker compose build
 OR
 ```bash
 docker pull intel/ai-tools:tlt-0.5.0
-docker pull intel/ai-tools:tlt-devel-0.5.0
-docker pull intel/ai-tools:tlt-dist-0.5.0
-docker pull intel/ai-tools:tlt-dist-devel-0.5.0
 ```
 
 ## Use Docker Image
@@ -56,11 +53,19 @@ OR
 helm repo add cowboysysop https://cowboysysop.github.io/charts/
 helm install <release name> cowboysysop/training-operator
 ```
+
+### 3. Build Distributed Container
+```bash
+cd docker
+docker compose build
+docker push <registry>:tlt-dist-latest
+```
+
 ### 3. Deploy TLT Distributed Job
 For more customization information, see the chart [README](./docker/chart/README.md)
 ```bash
 export NAMESPACE=kubeflow
-helm install --namespace ${NAMESPACE} --set ... tlt-distributed ./docker/chart
+helm install --namespace ${NAMESPACE} --set imageName=<registry> --set imageTag=tlt-dist-latest --set ... tlt-distributed ./docker/chart
 ```
 ### 4. View 
 To view your workflow progress


### PR DESCRIPTION
1. Added link to datasets md page when it is first mentioned under _features_. 
**Rationale:** this is where built-in datasets are first mentioned and the link is now closer to the support models, making navigation between the two easier.

2. Certain links were pointing at .md files which were themselves simply pointing at the github.io documents. I rerouted the link to go directly to the github.io.
**Rationale:** easier navigation with less files
